### PR TITLE
Add new Zimbabwe Gold

### DIFF
--- a/conf/currency_non_iso.json
+++ b/conf/currency_non_iso.json
@@ -142,5 +142,21 @@
     "thousands_separator": ",",
     "iso_numeric": "",
     "smallest_denomination": 1
+  },
+  "zig": {
+    "priority": 100,
+    "iso_code": "ZIG",
+    "name": "Zimbabwe Gold",
+    "symbol": "ZiG",
+    "disambiguate_symbol": "ZIG",
+    "alternate_symbols": [],
+    "subunit": "Cent",
+    "subunit_to_unit": 100,
+    "symbol_first": false,
+    "html_entity": "",
+    "decimal_mark": ".",
+    "thousands_separator": ",",
+    "iso_numeric": "",
+    "smallest_denomination": 1
   }
 }


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Zimbabwe_Gold "has been the official currency of Zimbabwe since 8 April 2024 [... banknotes] began circulating on 30 April 2024"